### PR TITLE
convert html to markdown

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -711,6 +711,21 @@ win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
 dev = ["Sphinx (==7.2.5)", "colorama (==0.4.5)", "colorama (==0.4.6)", "exceptiongroup (==1.1.3)", "freezegun (==1.1.0)", "freezegun (==1.2.2)", "mypy (==v0.910)", "mypy (==v0.971)", "mypy (==v1.4.1)", "mypy (==v1.5.1)", "pre-commit (==3.4.0)", "pytest (==6.1.2)", "pytest (==7.4.0)", "pytest-cov (==2.12.1)", "pytest-cov (==4.1.0)", "pytest-mypy-plugins (==1.9.3)", "pytest-mypy-plugins (==3.0.0)", "sphinx-autobuild (==2021.3.14)", "sphinx-rtd-theme (==1.3.0)", "tox (==3.27.1)", "tox (==4.11.0)"]
 
 [[package]]
+name = "markdownify"
+version = "0.13.1"
+description = "Convert HTML to markdown."
+optional = false
+python-versions = "*"
+files = [
+    {file = "markdownify-0.13.1-py3-none-any.whl", hash = "sha256:1d181d43d20902bcc69d7be85b5316ed174d0dda72ff56e14ae4c95a4a407d22"},
+    {file = "markdownify-0.13.1.tar.gz", hash = "sha256:ab257f9e6bd4075118828a28c9d02f8a4bfeb7421f558834aa79b2dfeb32a098"},
+]
+
+[package.dependencies]
+beautifulsoup4 = ">=4.9,<5"
+six = ">=1.15,<2"
+
+[[package]]
 name = "openai"
 version = "1.51.2"
 description = "The official Python library for the openai API"
@@ -1075,6 +1090,17 @@ files = [
 ]
 
 [[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -1197,4 +1223,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "6036ca184065875d15b306171d7b842cc4ce0e597f6d4c20d3d1e3103a5e88f6"
+content-hash = "5c10374eaeddc92c784cf418986a8cb758f0aaaf56a09f31634908ff64c02c84"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ click = "^8.1.7"
 openai = "^1.51.2"
 pydantic = "^2.9.2"
 google-generativeai = "^0.8.3"
+markdownify = "^0.13.1"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This pull request introduces new functionality to handle markdown conversion and image removal in the `changelog_helper/loaders/html.py` file. It also updates dependencies to include the `markdownify` library.

### New Functionality:

* [`changelog_helper/loaders/html.py`](diffhunk://#diff-75692c967e19fe0ae6b887561fbec8c3683ecef37edc3e98e8a719743f88025eR2-R16): Added a new function `remove_base64_image` to remove base64-encoded images from markdown text.
* [`changelog_helper/loaders/html.py`](diffhunk://#diff-75692c967e19fe0ae6b887561fbec8c3683ecef37edc3e98e8a719743f88025eL50-R58): Modified the `load_html_with_httpx` function to include an optional `markdown` parameter, which converts HTML to markdown and removes base64-encoded images if set to `True`. [[1]](diffhunk://#diff-75692c967e19fe0ae6b887561fbec8c3683ecef37edc3e98e8a719743f88025eL50-R58) [[2]](diffhunk://#diff-75692c967e19fe0ae6b887561fbec8c3683ecef37edc3e98e8a719743f88025eR68-R72)

### Dependency Updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R18): Added `markdownify` as a new dependency to support HTML to markdown conversion.